### PR TITLE
feat(booth) Basic translation of booth

### DIFF
--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -11,6 +11,8 @@ https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 
 import os
+from django.utils.translation import ugettext_lazy # for booth i18n
+
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -75,6 +77,7 @@ BASEURL = 'http://localhost:8000'
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.locale.LocaleMiddleware', # for booth i18n
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -140,7 +143,19 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/2.0/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+# List of supported languages
+LANGUAGES = (
+    ('en', ugettext_lazy('English')),
+    ('es', ugettext_lazy('Spanish')),
+)
+
+# Default language: Spanish (Spain)
+LANGUAGE_CODE = 'es-ES'
+
+# Location of directory that contains translation files
+LOCALE_PATHS = (
+    'locale',
+)
 
 TIME_ZONE = 'UTC'
 

--- a/decide/locale/es/LC_MESSAGES/django.po
+++ b/decide/locale/es/LC_MESSAGES/django.po
@@ -1,0 +1,56 @@
+# Translation of the decide booth web interface to Spanish.
+# Copyright (C) 2019 decide-articuno
+# This file is distributed under the same license as decide.
+# Miguel Macarro Klepsch <migmackle@alum.us.es>, 2019.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-12-11 12:04+0000\n"
+"PO-Revision-Date: 2019-12-11 11:59+0000\n"
+"Last-Translator: Miguel Macarro Klepsch <migmackle@alum.us.es>\n"
+"Language-Team: Spanish <migmackle@alum.us.es>\n"
+"Language: Spanish\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: booth/templates/booth/booth.html:19
+msgid "logout"
+msgstr "Salir"
+
+#: booth/templates/booth/booth.html:33
+msgid "Username"
+msgstr "Usuario"
+
+#: booth/templates/booth/booth.html:41
+msgid "Password"
+msgstr "Contraseña"
+
+#: booth/templates/booth/booth.html:49
+msgid "Login"
+msgstr "Entrar"
+
+#: booth/templates/booth/booth.html:64
+msgid "Vote"
+msgstr "Votar"
+
+#: booth/templates/booth/booth.html:160 booth/templates/booth/booth.html:170
+#: booth/templates/booth/booth.html:201
+msgid "Error: "
+msgstr "Error: "
+
+#: booth/templates/booth/booth.html:198
+msgid "Congratulations. Your vote has been sent"
+msgstr "Enhorabuena. Su voto ha sido enviado"
+
+#: local_settings.py:59
+msgid "English"
+msgstr "Inglés"
+
+#: local_settings.py:60
+msgid "Spanish"
+msgstr "Español"


### PR DESCRIPTION
Added Spanish translation files for booth UI to locale directory.

Changed settings.py: Changed default locale to es-ES, indicated list of
available languages (English and Spanish for now) and location of translation
files (locale directory).

For now, the booth will be displayed in English if the user's browser requests
the page in English, in all other cases it will be displayed in Spanish, which
is the default language.